### PR TITLE
fix: not running other autocmd

### DIFF
--- a/lua/actually/init.lua
+++ b/lua/actually/init.lua
@@ -46,6 +46,7 @@ return {
 
     api.nvim_create_autocmd("BufNewFile", {
       pattern = "*",
+      nested = true,
       callback = Actually,
       group = augroup
     })


### PR DESCRIPTION
Problem:

Things like `treesitter` and `lsp` don't work correctly when using the plugin.

![image](https://github.com/user-attachments/assets/303a051e-9c52-4ffd-9179-47bff504d191)

Notice my buffer has no treesitter highlight and bottom right says "No servers", you can run `LspInfo` to check that no clients are attached.

---

Solution:

Uses `nested = true` for the `BufNewFile` autocmd.

I honestly don’t fully understand why this works, which explains why my commit message description is so vague.

I copy what [lewis6991/fileline.nvim](https://github.com/lewis6991/fileline.nvim) does which works since it has the same workflow.